### PR TITLE
Link to GitHub help pages for terms in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A great example repo you can fork to your heart’s content, that serves as a la
 
 ## Getting started
 
-The first thing you want to do with this repo is quite likely [**fork it**](http://github.com).  Use the Fork button in the top-right section of the page to do this.
+The first thing you want to do with this repo is quite likely [**fork it**](https://help.github.com/articles/fork-a-repo).  Use the Fork button in the top-right section of the page to do this.
 
 Once you’re on your fork, you can experiment however you like with it, play with branches, issues, milestones, labels, the wiki, and more.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A great example repo you can fork to your heart’s content, that serves as a la
 
 The first thing you want to do with this repo is quite likely [**fork it**](https://help.github.com/articles/fork-a-repo).  Use the Fork button in the top-right section of the page to do this.
 
-Once you’re on your fork, you can experiment however you like with it, play with branches, issues, milestones, labels, the wiki, and more.
+Once you’re on your fork, you can experiment however you like with it, play with [branches](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository), [issues](https://help.github.com/articles/about-issues), [milestones](https://help.github.com/articles/associating-milestones-with-issues-and-pull-requests), [labels](https://help.github.com/articles/applying-lables-to-issues-and-pull-requests), the [wiki](https://help.github.com/articles/about-gihub-wikis), and more.
 
 ## What’s in there?
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A great example repo you can fork to your heart’s content, that serves as a la
 
 The first thing you want to do with this repo is quite likely [**fork it**](https://help.github.com/articles/fork-a-repo).  Use the Fork button in the top-right section of the page to do this.
 
-Once you’re on your fork, you can experiment however you like with it, play with [branches](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository), [issues](https://help.github.com/articles/about-issues), [milestones](https://help.github.com/articles/associating-milestones-with-issues-and-pull-requests), [labels](https://help.github.com/articles/applying-lables-to-issues-and-pull-requests), the [wiki](https://help.github.com/articles/about-gihub-wikis), and more.
+Once you’re on your fork, you can experiment however you like with it, play with [branches](https://help.github.com/articles/viewing-branches-in-your-repository/), [issues](https://help.github.com/articles/about-issues), [milestones](https://help.github.com/articles/associating-milestones-with-issues-and-pull-requests), [labels](https://help.github.com/articles/applying-lables-to-issues-and-pull-requests), the [wiki](https://help.github.com/articles/about-gihub-wikis), and more.
 
 ## What’s in there?
 


### PR DESCRIPTION
The README stresses that this repo is intended for forks, but GitHub newbies 
may have no idea what these are about, so we link to the official docs!

We provide even more links to GitHub help for newbies: branch management, issues, milestones, labels and wikis.
